### PR TITLE
Fix parse_records KeyError for invalid DICOMDIR offsets

### DIFF
--- a/pydicom/dicomdir.py
+++ b/pydicom/dicomdir.py
@@ -143,8 +143,16 @@ class DicomDir(FileDataset):
                     record.OffsetOfReferencedLowerLevelDirectoryEntity
                 )
                 if child_offset:
-                    child = map_offset_to_record[child_offset]
-                    record.children = get_siblings(child, map_offset_to_record)
+                    try:
+                        child = map_offset_to_record[child_offset]
+                    except KeyError:
+                        warnings.warn(
+                            "Invalid child offset in directory record - "
+                            f"no record found at {child_offset}",
+                            UserWarning,
+                        )
+                    else:
+                        record.children = get_siblings(child, map_offset_to_record)
 
         self.patient_records = [
             record for record in records

--- a/pydicom/fileset.py
+++ b/pydicom/fileset.py
@@ -1768,14 +1768,29 @@ class FileSet:
         def recurse_node(node: RecordNode) -> None:
             child_offset = getattr(node._record, _LOWER_OFFSET, None)
             if child_offset:
-                child = records[child_offset]
-                child.parent = node
-
-                next_offset = getattr(child._record, _NEXT_OFFSET, None)
-                while next_offset:
-                    child = records[next_offset]
+                child = records.get(child_offset)
+                if child:
                     child.parent = node
+
                     next_offset = getattr(child._record, _NEXT_OFFSET, None)
+                    while next_offset:
+                        nxt = records.get(next_offset)
+                        if not nxt:
+                            warnings.warn(
+                                "Invalid child offset in directory record - "
+                                f"no record found at {next_offset}",
+                                UserWarning,
+                            )
+                            break
+                        child = nxt
+                        child.parent = node
+                        next_offset = getattr(child._record, _NEXT_OFFSET, None)
+                else:
+                    warnings.warn(
+                        "Invalid child offset in directory record - "
+                        f"no record found at {child_offset}",
+                        UserWarning,
+                    )
             elif "ReferencedFileID" not in node._record:
                 # No children = leaf node, leaf nodes must reference a File ID
                 del node.parent[node]

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -2157,6 +2157,15 @@ class TestFileSet_Load:
         assert fs.UID.is_valid
         assert fs.UID == dicomdir.file_meta.MediaStorageSOPInstanceUID
 
+    def test_load_dicomdir_bad_offset(self, dicomdir):
+        """Test loading a DICOMDIR with an invalid child offset."""
+        item = dicomdir.DirectoryRecordSequence[0]
+        item.OffsetOfReferencedLowerLevelDirectoryEntity = 999999
+        msg = r"Invalid child offset in directory record"
+        with pytest.warns(UserWarning, match=msg):
+            fs = FileSet(dicomdir)
+        assert isinstance(fs, FileSet)
+
 
 class TestFileSet_Modify:
     """Tests for a modified File-set."""


### PR DESCRIPTION
## Summary
- warn instead of error when DICOMDIR references non-existent record offsets
- handle invalid offsets while building FileSet hierarchy
- add regression test for DICOMDIR with bad offsets

## Testing
- `pytest tests/test_fileset.py::TestFileSet_Load::test_load_dicomdir_bad_offset -q`
- `pytest tests/test_fileset.py::TestFileSet_Load::test_load_dicomdir_no_uid -q`
- `pytest tests/test_fileset.py::TestFileSet_Load::test_load_dicomdir_no_offset -q`
